### PR TITLE
Add unit tests, tox, and GitHub Actions to run them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Publish to PyPI
+on: [release]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine wheel
+    - name: Build the package
+      run: |
+        python setup.py sdist bdist_wheel --universal
+    - name: Upload to PyPI
+      run: twine upload dist/*
+      env: 
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: test
+
+on: [push]
+
+jobs:
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+  
+      - name: Run tox -e lint
+        run: tox
+        env: 
+          TOXENV: lint
+
+  test:
+    name: unittests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        toxenv:
+            - py27
+            - py36
+        include:
+          - toxenv: py27
+            python-version: 2.7
+          - toxenv: py36
+            python-version: 3.6
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Run tox
+        run: |
+            tox
+        env: 
+          TOXENV: ${{ matrix.toxenv }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ To lint and run the unit tests you will need to:
 1. Install Tox in a virtualenv or your local Python environment: `pip install tox`
 2. Run tox: `tox`
 
-
 ## Open source licensing info
 1. [TERMS](TERMS.md)
 2. [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ We've also added a crucial check that allows front-end build failures to propoga
 
 Edit your package's 'setup.py' to require this module at build-time (`setup_requires=['cfgov-setup']`), and set the 'do_frontend_build' keyword in the setup arguments. [This pull request](https://github.com/cfpb/complaint/pull/10) demonstrates the kind of changes to make.
 
+## Testing
+
+To lint and run the unit tests you will need to:
+
+1. Install Tox in a virtualenv or your local Python environment: `pip install tox`
+2. Run tox: `tox`
+
 
 ## Open source licensing info
 1. [TERMS](TERMS.md)

--- a/cfgov_setup/__init__.py
+++ b/cfgov_setup/__init__.py
@@ -1,12 +1,9 @@
-import os
-
 from distutils.command.build_ext import build_ext
-from setuptools.command.bdist_egg import bdist_egg
-from wheel.bdist_wheel import bdist_wheel
+from subprocess import check_call
 
 from setuptools import Command
-
-from subprocess import check_call
+from setuptools.command.bdist_egg import bdist_egg
+from wheel.bdist_wheel import bdist_wheel
 
 
 def make_build_frontend_command(script_name):
@@ -18,11 +15,11 @@ def make_build_frontend_command(script_name):
             check_call(['sh', script_name])
 
         def initialize_options(self):
-            """ API requires that we override this, but we have nothing to do"""
+            """API requires that we override this, but we have nothing to do"""
             pass
 
         def finalize_options(self):
-            """ API requires that we override this, but we have nothing to do"""
+            """API requires that we override this, but we have nothing to do"""
             pass
 
     return build_frontend
@@ -35,6 +32,7 @@ def wrap_command(original_command):
             original_command.run(self)
 
     return new_command
+
 
 def do_frontend_build(dist, key, script_name):
     commands = {

--- a/cfgov_setup/tests.py
+++ b/cfgov_setup/tests.py
@@ -1,0 +1,25 @@
+import unittest
+
+from mock import patch
+from distutils.tests import support
+
+
+class CFGovDjangoSetup(support.TempdirManager, unittest.TestCase):
+
+    def setUp(self):
+        super(CFGovDjangoSetup, self).setUp()
+
+        metadata = {'frontend_build_script': 'myscript.sh'}
+        pkg_info, self.dist = self.create_dist(**metadata)
+
+    @patch('cfgov_setup.check_call')
+    def test_build_frontend(self, mock_check_call):
+        # Run build_frontend
+        self.dist.run_command('build_frontend')
+        mock_check_call.assert_called_once_with(['sh', 'myscript.sh'])
+
+    @patch('cfgov_setup.check_call')
+    def test_wrap_command(self, mock_check_call):
+        # Run build_ext
+        self.dist.run_command('build_ext')
+        mock_check_call.assert_called_once_with(['sh', 'myscript.sh'])

--- a/cfgov_setup/tests.py
+++ b/cfgov_setup/tests.py
@@ -1,7 +1,7 @@
 import unittest
+from distutils.tests import support
 
 from mock import patch
-from distutils.tests import support
 
 
 class CFGovDjangoSetup(support.TempdirManager, unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ def read_file(filename):
         return ''
 
 
+testing_extras = [
+    'coverage>=4.5.4',
+    'mock>=2.0.0',
+]
+
 
 setup(
     name='cfgov-setup',
@@ -28,4 +33,8 @@ setup(
             'frontend_build_script=cfgov_setup:do_frontend_build'
         ]
     },
+    extras_require={
+        'testing': testing_extras,
+    },
+    test_suite='cfgov_setup.tests',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 def read_file(filename):
@@ -11,14 +11,21 @@ def read_file(filename):
     except IOError:
         return ''
 
-setup(name='cfgov-setup',
-      version='1.1',
-      py_modules='cfgov_setup',
-      url='https://github.com/cfpb/cfgov-django-setup',
-      maintainer= 'CFPB',
-      maintainer_email='tech@cfpb.gov',
-      long_description=read_file('README.md'),
-      entry_points={'distutils.setup_keywords':
-               ['frontend_build_script=cfgov_setup:do_frontend_build']
-           }
-      )
+
+
+setup(
+    name='cfgov-setup',
+    version='1.2',
+    py_modules=['cfgov_setup', ],
+    url='https://github.com/cfpb/cfgov-django-setup',
+    maintainer='CFPB',
+    maintainer_email='tech@cfpb.gov',
+    long_description=read_file('README.md'),
+    long_description_content_type='text/markdown',
+    packages=find_packages(),
+    entry_points={
+        'distutils.setup_keywords': [
+            'frontend_build_script=cfgov_setup:do_frontend_build'
+        ]
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 def read_file(filename):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist=lint,py{27,36}
+
+[testenv]
+install_command=pip install -e '.[testing]' {packages}
+commands=
+    coverage erase
+    coverage run --source='cfgov_setup' -m unittest cfgov_setup.tests {posargs}
+    coverage report -m
+
+basepython=
+    py27: python2.7
+    py36: python3.6
+
+[testenv:lint]
+basepython=python3.6
+deps=
+    flake8>=2.2.0
+    isort>=4.2.15
+commands=
+    flake8 cfgov_setup
+    isort --check-only --diff cfgov_setup

--- a/tox.ini
+++ b/tox.ini
@@ -19,4 +19,4 @@ deps=
     isort>=4.2.15
 commands=
     flake8 cfgov_setup
-    isort --check-only --diff cfgov_setup
+    isort --check-only --diff --recursive cfgov_setup


### PR DESCRIPTION
This PR adds unit tests for cfgov-django-setup and adds tox to run them. It also adds a GitHub Actions workflow to run the tests and a workflow to submit a new release to PyPI (based on [the same workflows in Django-Flags](https://github.com/cfpb/django-flags/tree/master/.github/workflows).

It also reorganizes `cfgov_setup` as a Python package instead of simply a module. This is mostly for name-spacing of the tests and consistency with our other Python packages.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
