### PR TITLE
Add flake8 and isort configs and fix errors 

### DIFF
--- a/cfgov_setup/__init__.py
+++ b/cfgov_setup/__init__.py
@@ -36,9 +36,9 @@ def wrap_command(original_command):
 
 def do_frontend_build(dist, key, script_name):
     commands = {
-       'build_frontend': make_build_frontend_command(script_name),
-       'build_ext': wrap_command(build_ext),
-       'bdist_egg': wrap_command(bdist_egg),
-       'bdist_wheel': wrap_command(bdist_wheel)
+        'build_frontend': make_build_frontend_command(script_name),
+        'build_ext': wrap_command(build_ext),
+        'bdist_egg': wrap_command(bdist_egg),
+        'bdist_wheel': wrap_command(bdist_wheel)
     }
     dist.cmdclass.update(commands)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ testing_extras = [
 
 setup(
     name='cfgov-setup',
-    version='1.2',
+    version='1.3',
     py_modules=['cfgov_setup', ],
     url='https://github.com/cfpb/cfgov-django-setup',
     maintainer='CFPB',

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,29 @@ deps=
 commands=
     flake8 cfgov_setup
     isort --check-only --diff --recursive cfgov_setup
+
+[flake8]
+ignore = 
+    # Allow assigning lambda expressions
+    E731,
+    # Allow line breaks after binary operators
+    W503,
+    # Allow line breaks before binary operators
+    W504,
+
+exclude =
+    # Some of this are excluded for speed of directory traversal. Not all of 
+    # them have Python files we wish to ignore.
+    .git,
+    .tox,
+    __pycache__
+
+[isort]
+include_trailing_comma=1
+multi_line_output=3
+not_skip=__init__.py
+use_parentheses=1
+known_future_library=future,six
+known_third_party=mock
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
I had left out our standard flake8 and isort configurations. This change includes them and fixes linting errors that were left in without them.

This PR also bumps the version number in anticipation of release.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
